### PR TITLE
Change access modifiers to allow custom gesture recognisers

### DIFF
--- a/uigesturerecognizer/src/main/java/it/sephiroth/android/library/uigestures/UIGestureRecognizer.java
+++ b/uigesturerecognizer/src/main/java/it/sephiroth/android/library/uigestures/UIGestureRecognizer.java
@@ -234,7 +234,7 @@ public abstract class UIGestureRecognizer implements OnGestureRecognizerStateCha
         }
     }
 
-    protected boolean inState(State... states) {
+    public boolean inState(State... states) {
         if (null == states || states.length < 1) {
             return false;
         }
@@ -326,7 +326,7 @@ public abstract class UIGestureRecognizer implements OnGestureRecognizerStateCha
         sDebug = enabled;
     }
 
-    void logMessage(int level, String fmt, Object... args) {
+    protected void logMessage(int level, String fmt, Object... args) {
         if (!sDebug) {
             return;
         }

--- a/uigesturerecognizer/src/main/java/it/sephiroth/android/library/uigestures/UIGestureRecognizerDelegate.java
+++ b/uigesturerecognizer/src/main/java/it/sephiroth/android/library/uigestures/UIGestureRecognizerDelegate.java
@@ -128,7 +128,7 @@ public class UIGestureRecognizerDelegate {
         return handled;
     }
 
-    boolean shouldRecognizeSimultaneouslyWithGestureRecognizer(final UIGestureRecognizer recognizer) {
+    public boolean shouldRecognizeSimultaneouslyWithGestureRecognizer(final UIGestureRecognizer recognizer) {
         Log.i(getClass().getSimpleName(), "shouldRecognizeSimultaneouslyWithGestureRecognizer(" + recognizer + ")");
         if (mSet.size() == 1) {
             return true;
@@ -147,7 +147,7 @@ public class UIGestureRecognizerDelegate {
         return result;
     }
 
-    protected boolean shouldBegin(UIGestureRecognizer recognizer) {
+    public boolean shouldBegin(UIGestureRecognizer recognizer) {
         return null == mCallback || mCallback.shouldBegin(recognizer);
     }
 


### PR DESCRIPTION
We have opened up the api for extension, we currently have in use a custom gesture recognizer that is not in the `it.sephiroth.android.library.uigestures` package.